### PR TITLE
Small Fixes

### DIFF
--- a/FolderStructure.lua
+++ b/FolderStructure.lua
@@ -17,7 +17,7 @@ if f == nil then
     f:close()
 end
 
-local f = io.open(corename.."/src/corepch.h","r")
+local f = io.open(corename.."/src/corepch.cpp","r")
 
 if f == nil then
     local f = io.open(corename.."/src/corepch.cpp","w")

--- a/premake5.lua
+++ b/premake5.lua
@@ -3,7 +3,7 @@ include "FolderStructure.lua"
 workspace (solutionname)
     language "C++"
     cppdialect "C++17"
-    architecture "x64"
+    architecture "x86_64"
     systemversion "latest"
     characterset "Unicode"
     startproject (appname)


### PR DESCRIPTION
Fixed a typo checking for corepch.h instead of corepch.cpp
Changed architecture from x64 to x86_64 as x64 is an alias for x86_64 and may be deprecated in the future ( https://premake.github.io/docs/architecture/ )